### PR TITLE
Make flannel role dependent from docker

### DIFF
--- a/roles/flannel/meta/main.yml
+++ b/roles/flannel/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+    - { role: docker }


### PR DESCRIPTION
This prevents error when installing flannel on master nodes.